### PR TITLE
switch to pycryptodome - a maintained fork of pycrypto

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This is better:
  * pyasn1 0.1.7+
  * pyasn1_modules 0.0.8+
  * javaobj-py3 0.1.4+
- * pycrypto, if you need to read JCEKS, BKS or UBER keystores
+ * pycryptodome, if you need to read JCEKS, BKS or UBER keystores
  * twofish, if you need to read UBER keystores
 
 ## Usage examples:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pyasn1==0.1.7
 pyasn1_modules==0.0.8
 javaobj-py3==0.2.1
-pycrypto==2.6.1
+pycryptodome==3.4.5
 twofish==0.3.0

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     install_requires=['pyasn1',
                       'pyasn1_modules',
                       'javaobj-py3',
-                      'pycrypto',
+                      'pycryptodome',
                       'twofish'],
     test_suite="tests.test_jks",
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py34,py35,pypy
+envlist = py26,py27,py34,py35,py36,pypy
 [testenv]
 changedir = .tox
 deps = -rrequirements-test.txt


### PR DESCRIPTION
https://pypi.python.org/pypi/pycryptodome - maintained, many additions and binary wheels!
add py36 to tox.

Tested on windows py35 & py36.
