### PR TITLE
CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,10 @@
 language: python
-python: 3.5
-env:
-  - TOX_ENV=py36
-  - TOX_ENV=py35
-  - TOX_ENV=py34
-  - TOX_ENV=py27
+python:
+  - "2.7"
+  - "3.4"
+  - "3.5"
+  - "3.6"
 install:
   - pip install tox
 script:
-  - tox -e $TOX_ENV
-  
+  - tox -e py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: python
+python: 3.5
+env:
+  - TOX_ENV=py36
+  - TOX_ENV=py35
+  - TOX_ENV=py34
+  - TOX_ENV=py27
+install:
+  - pip install tox
+script:
+  - tox -e $TOX_ENV
+  

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This is better:
  * pyasn1 0.1.7+
  * pyasn1_modules 0.0.8+
  * javaobj-py3 0.1.4+
- * pycrypto, if you need to read JCEKS, BKS or UBER keystores
+ * pycryptodome, if you need to read JCEKS, BKS or UBER keystores
  * twofish, if you need to read UBER keystores
 
 ## Usage examples:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,29 @@
+version: build-{build}-{branch}
+
+environment:
+  matrix:
+    # http://www.appveyor.com/docs/installed-software#python lists available
+    # versions
+    - PYTHON: "C:\\Python27"
+    - PYTHON: "C:\\Python27-x64"
+    - PYTHON: "C:\\Python34"
+    - PYTHON: "C:\\Python34-x64"
+    - PYTHON: "C:\\Python35"
+    - PYTHON: "C:\\Python35-x64"
+    - PYTHON: "C:\\Python36"
+    - PYTHON: "C:\\Python36-x64"
+
+init:
+  - "echo %PYTHON%"
+
+install:
+  - "set PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+  - python --version
+  - python -m pip install -U pip
+  - python -m pip install -U setuptools
+  - python -m pip install -U wheel virtualenv tox
+
+build: false
+
+test_script:
+  - tox -v -e py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pyasn1==0.1.7
 pyasn1_modules==0.0.8
 javaobj-py3==0.2.1
-pycrypto==2.6.1
+pycryptodome==3.4.5
 twofish==0.3.0

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     install_requires=['pyasn1',
                       'pyasn1_modules',
                       'javaobj-py3',
-                      'pycrypto',
+                      'pycryptodome',
                       'twofish'],
     test_suite="tests.test_jks",
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py34,py35,pypy
+envlist = py26,py27,py34,py35,py36,pypy
 [testenv]
 changedir = .tox
 deps = -rrequirements-test.txt


### PR DESCRIPTION
Add basic travis & appveyor CI integration.
appveyor fails on Python 2.7 due to twofish dependency build failure.
requires #30 .
Possible next steps:
* added appveyor & travis shields https://shields.io/
* replace twofish dependency with something else.
