### PR TITLE
Fix for: Pyjks doesn't convert alias to lowercase (#38)

### DIFF
--- a/jks/jks.py
+++ b/jks/jks.py
@@ -77,7 +77,8 @@ class TrustedCertEntry(AbstractKeystoreEntry):
         timestamp = int(time.time()) * 1000
 
         tke = cls(timestamp = timestamp,
-                               alias = alias,
+                               # Alias must be lower case or it will corrupt the keystore for Java Keytool and Keytool Explorer
+                               alias = alias.lower(),
                                cert = cert)
         return tke
 
@@ -139,7 +140,8 @@ class PrivateKeyEntry(AbstractKeystoreEntry):
             cert_chain.append(('X.509', cert))
 
         pke = cls(timestamp = timestamp,
-                               alias = alias,
+                               # Alias must be lower case or it will corrupt the keystore for Java Keytool and Keytool Explorer
+                               alias = alias.lower(),
                                cert_chain = cert_chain)
 
         if key_format == 'pkcs8':

--- a/tests/test_jks.py
+++ b/tests/test_jks.py
@@ -284,6 +284,18 @@ class JksTests(AbstractTest):
         sk = self.find_secret_key(store, "mykey")
         self.assertRaises(jks.util.UnsupportedKeystoreEntryTypeException, jks.KeyStore.new, 'jks', [sk])
 
+    def test_alias_lower_certificate(self):
+        cert = jks.TrustedCertEntry.new('CERT', expected.RSA2048_3certs.certs[0])
+        keystore = jks.KeyStore.new('jks', [cert])
+        alias = list(keystore.certs.keys())[0]
+        self.assertTrue(alias.islower())
+
+    def test_alias_lower_pkey(self):
+        pkey = jks.PrivateKeyEntry.new('PKEY', expected.RSA2048_3certs.certs, expected.RSA2048_3certs.private_key)
+        keystore = jks.KeyStore.new('jks', [pkey])
+        alias = list(keystore.private_keys.keys())[0]
+        self.assertTrue(alias.islower())
+
 class JceTests(AbstractTest):
     def test_empty_store(self):
         store = jks.KeyStore.load(KS_PATH + "/jceks/empty.jceks", "")


### PR DESCRIPTION
Alias will now be converted to lowercase when creating certificate/private key entries. Added some tests also.