### PR TITLE
pycryptodome -> pycryptodomex; Crypto -> Cryptodome

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This is better:
  * pyasn1 0.3.5+
  * pyasn1_modules 0.0.8+
  * javaobj-py3 0.1.4+
- * pycryptodome, if you need to read JCEKS, BKS or UBER keystores
+ * pycryptodomex, if you need to read JCEKS, BKS or UBER keystores
  * twofish, if you need to read UBER keystores
 
 ## Usage examples:

--- a/jks/bks.py
+++ b/jks/bks.py
@@ -3,7 +3,7 @@ import struct
 import hashlib
 from pyasn1.codec.ber import decoder
 from pyasn1_modules import rfc5208, rfc2459
-from Crypto.Hash import HMAC, SHA
+from Cryptodome.Hash import HMAC, SHA
 
 from .util import *
 from .jks import KeyStore, TrustedCertEntry

--- a/jks/rfc7292.py
+++ b/jks/rfc7292.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 import hashlib
 import ctypes
 from pyasn1.type import univ, namedtype
-from Crypto.Cipher import DES3
+from Cryptodome.Cipher import DES3
 from .util import xor_bytearrays, add_pkcs7_padding, strip_pkcs7_padding, BadDataLengthException
 
 PBE_WITH_SHA1_AND_TRIPLE_DES_CBC_OID = (1,2,840,113549,1,12,1,3)

--- a/jks/sun_crypto.py
+++ b/jks/sun_crypto.py
@@ -65,7 +65,7 @@ def jce_pbe_decrypt(data, password, salt, iteration_count):
     """
     key, iv = _jce_pbe_derive_key_and_iv(password, salt, iteration_count)
 
-    from Crypto.Cipher import DES3
+    from Cryptodome.Cipher import DES3
     des3 = DES3.new(key, DES3.MODE_CBC, IV=iv)
     padded = des3.decrypt(data)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pyasn1==0.3.5
 pyasn1_modules==0.0.8
 javaobj-py3==0.2.1
-pycryptodome==3.4.5
+pycryptodomex==3.4.5
 twofish==0.3.0

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
     install_requires=['pyasn1>=0.3.5',
                       'pyasn1_modules',
                       'javaobj-py3',
-                      'pycryptodome',
+                      'pycryptodomex',
                       'twofish'],
     test_suite="tests.test_jks",
 )


### PR DESCRIPTION
pycryptodome is designed to be a drop-in replacement for pycrypto, however in some cases, pycryptodome is not fully compatible with pycrypto. I have ran in to one of these scenarios. My service has a third-party dependency which requires pycrypto, and pycryptodome is not able to replicate the functionality that this library requires.

pycryptodomex is the same as pycryptodome, however it doesn't function as a drop-in replacement and will not replace the Crypto class. More details about this exist here: https://pycryptodome.readthedocs.io/en/latest/src/installation.html
