### PR TITLE
Enable twofish as an optional dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,8 +57,10 @@ setup(
     install_requires=['pyasn1>=0.3.5',
                       'pyasn1_modules',
                       'javaobj-py3',
-                      'pycryptodomex',
-                      'twofish'],
+                      'pycryptodomex'],
+    extras_require={
+      'twofish': ['twofish'],
+    },
     test_suite="tests.test_jks",
 )
 


### PR DESCRIPTION
**Problem:**

As of now `pyjks` requires the install of `twofish`, even though according to the README `twofish` is only required to read UBER keystores. `twofish` is a package that has no commits since 2013 and is not compatible with Python 3.3+. Installing `twofish` should be optional.

**Solution:**

Enable `twofish` to be installed as an `extras_require`.

**Testing:**

I was able to build with Python 2 and Python 3 without issues, with and without `twofish`. `tox` tests pass for all Python versions there are tests for.

**Notes:**

- See #68 for the previous draft version of this PR with a polluted commit history. The previous change included various changes to `setup.cfg` and `requirements.txt` that are not required to enable `twofish` to be installed optionally.
- **Question:** Can we increment the version number as part of this change?